### PR TITLE
Fix error running mydynamiccommand with --help

### DIFF
--- a/src/hooks/init/addcommand.ts
+++ b/src/hooks/init/addcommand.ts
@@ -15,6 +15,7 @@ class DynamicPlugin extends Config.Plugin {
     const cmd = class extends Command {
       static id = 'mydynamiccommand'
       static load() { return cmd }
+      static args = [{ name: 'path' }]
       async run() {
         ux.log('running mydynamiccommand')
       }


### PR DESCRIPTION
Fix an error that would occur when running `bin/run mydynamiccommand --help`:

Before:
-------

```
$ bin/run mydynamiccommand --help
TypeError: Cannot read property 'filter' of undefined
    at CommandHelp.defaultUsage (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/command.js:51:26)
    at CommandHelp.usage (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/command.js:40:69)
    at CommandHelp.command (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/command.js:28:18)
    at Help.command (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/index.js:107:21)
    at Help.showCommandHelp (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/index.js:75:26)
    at Help.showHelp (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/plugin-help/lib/index.js:52:18)
    at Main._help (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/command/lib/main.js:41:14)
    at Main.init (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/command/lib/command.js:63:25)
    at Main.init (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/command/lib/main.js:11:22)
    at Main._run (~/dev/git-repos/oclif-example-dynamic-commands/node_modules/@oclif/command/lib/command.js:28:13)
```

After:
------

```
$ bin/run mydynamiccommand --help
USAGE
  $ oclif-example-dynamic-commands mydynamiccommand [PATH]
```

Fixes: GH-3